### PR TITLE
Getting the card details in expense listing

### DIFF
--- a/models/expense.js
+++ b/models/expense.js
@@ -1,5 +1,6 @@
 const { sequelize } = require("../config/database")
 const { DataTypes } = require("sequelize");
+const paymentCards = require("./cards");
 
 const Expense = sequelize.define(
   "expenses",
@@ -77,5 +78,12 @@ sequelize
   .catch((error) => {
     console.error("Unable to create table : ", error);
   });
+
+Expense.hasOne(paymentCards, {
+  sourceKey: 'card_id',
+  foreignKey: 'id',
+  as: 'payment_cards'
+});
+
 
 module.exports = Expense;

--- a/services/expense.js
+++ b/services/expense.js
@@ -1,6 +1,7 @@
 const Expense = require("../models/expense");
 const { Op, Sequelize } = require("sequelize");
 const { sequelize } = require("../config/database");
+const paymentCards = require("../models/cards");
 
 async function addNewExpense(
   source_id,
@@ -32,13 +33,37 @@ async function getAllExpenses(user_id) {
   try {
     let expenses = await Expense.findAndCountAll({
       where: { created_by: user_id, is_deleted: 0 },
+      attributes: [
+        "id",
+        "source_id",
+        "method_id",
+        "amount",
+        "description",
+        "date",
+        "created_by",
+        "updated_by",
+        "is_deleted",
+        "is_repayed",
+        "tag",
+        "category_id",
+        "card_id",
+        [sequelize.col("payment_cards.name"), "card_name"]
+      ],
+      raw: true,
+      include: [
+        {
+          model: paymentCards,
+          as: "payment_cards",
+          attributes: [],
+        },
+      ],
       order: [
         ["date", "DESC"],
         ["id", "DESC"],
       ],
     });
     if (expenses.count > 0)
-      return { rows: expenses.rows, count: expenses.count };
+       return { rows: expenses.rows, count: expenses.count };
     else return { rows: [], count: 0 };
   } catch (error) {
     throw error;

--- a/typeDefs/expense.js
+++ b/typeDefs/expense.js
@@ -39,6 +39,7 @@ const expenseTypeDef = /* GraphQL */
     tag: String 
     category_id: Int
     card_id: Int
+    card_name: String
   }
 
   type deleteExpenseObject {


### PR DESCRIPTION
**Summary**
This PR ensures card_name is returned correctly from the expenses query by making Sequelize return plain objects (raw results), so GraphQL can reliably resolve the aliased field.
**What changed**
Updated getAllExpenses() in services/expense.js to use raw: true in Expense.findAndCountAll(...).
Kept the existing alias [sequelize.col("payment_cards.name"), "card_name"] intact and returned expenses.rows directly.
**Why**
Sequelize aliased attributes (like card_name) may not be exposed as direct properties on model instances, causing GraphQL to omit them. Using raw: true returns plain objects where card_name is a real key.