### PR TITLE
Support updating expenses with optional card association

### DIFF
--- a/resolvers/expense.js
+++ b/resolvers/expense.js
@@ -13,6 +13,7 @@ const {
   getExpensePerWeekInCurMon,
   getExpensePerMonInCurYear,
   addNewExpenseV2,
+  updateAnExpenseV2
 } = require("../services/expense");
 const { getPaymentSourceById } = require("../services/sources");
 const { getPaymentMethodById } = require("../services/method");
@@ -82,10 +83,40 @@ const expense_resolvers = {
     },
     updateExpense: async (
       _,
-      { id, source_id, method_id, amount, description, date, created_by, updated_by, tag, is_repayed },
+      { id, source_id, method_id, amount, description, date, created_by, updated_by, tag, is_repayed, card_id },
       { logged_userid }
     ) => {
-      const updateResult = await updateAnExpense(id, source_id, method_id, amount, description, date, created_by, updated_by, tag, is_repayed);
+      let updateResult;
+      if (card_id) {
+        // Call the V2 function if card_id is provided
+        updateResult = await updateAnExpenseV2(
+          id,
+          source_id,
+          method_id,
+          amount,
+          description,
+          date,
+          created_by,
+          updated_by,
+          tag,
+          is_repayed,
+          card_id,
+        );
+      } else {
+        // Present for backend compatibility
+        updateResult = await updateAnExpense(
+          id,
+          source_id,
+          method_id,
+          amount,
+          description,
+          date,
+          created_by,
+          updated_by,
+          tag,
+          is_repayed,
+        );
+      }
       return await getExpensesDetailsById(id);
     },
   },

--- a/services/expense.js
+++ b/services/expense.js
@@ -47,7 +47,7 @@ async function getAllExpenses(user_id) {
         "tag",
         "category_id",
         "card_id",
-        [sequelize.col("payment_cards.name"), "card_name"]
+        [sequelize.col("payment_cards.name"), "card_name"],
       ],
       raw: true,
       include: [
@@ -344,6 +344,41 @@ async function addNewExpenseV2(
   }
 }
 
+async function updateAnExpenseV2(
+  expense_id,
+  source_id,
+  method_id,
+  amount,
+  description,
+  date,
+  created_by,
+  updated_by,
+  tag,
+  is_repayed,
+  card_id
+) {
+  try {
+    const updateFields = {};
+    if (source_id !== undefined) updateFields.source_id = source_id;
+    if (method_id !== undefined) updateFields.method_id = method_id;
+    if (amount !== undefined) updateFields.amount = amount;
+    if (description !== undefined) updateFields.description = description;
+    if (date !== undefined) updateFields.date = date;
+    if (created_by !== undefined) updateFields.created_by = created_by;
+    if (updated_by !== undefined) updateFields.updated_by = updated_by;
+    if (tag !== undefined) updateFields.tag = tag;
+    if (is_repayed !== undefined) updateFields.is_repayed = is_repayed;
+    if (card_id !== undefined) updateFields.card_id = card_id;
+
+    if (Object.keys(updateFields).length > 0) {
+      updateFields.updated_at = new Date();
+      return await Expense.update(updateFields, { where: { id: expense_id } });
+    }
+  } catch (error) {
+    throw error;
+  }
+}
+
 
 module.exports = {
   addNewExpense,
@@ -360,4 +395,5 @@ module.exports = {
   getExpensePerWeekInCurMon,
   getExpensePerMonInCurYear,
   addNewExpenseV2,
+  updateAnExpenseV2
 };

--- a/typeDefs/expense.js
+++ b/typeDefs/expense.js
@@ -60,7 +60,7 @@ const expenseTypeDef = /* GraphQL */
 
   type Mutation {
       createExpense(source_id: Int, source: String, method_id: Int, method: String, amount: Float, description: String, date: String, tag: String, card_id: Int): Expense
-      updateExpense(id: Int!, source_id: Int, method_id: Int, amount: Float, description: String, date: String, created_by: Int, updated_by: Int, tag: String, is_repayed: Int): Expense
+      updateExpense(id: Int!, source_id: Int, method_id: Int, amount: Float, description: String, date: String, created_by: Int, updated_by: Int, tag: String, is_repayed: Int ,card_id: Int): Expense
       deleteExpense(ids: [Int]): deleteExpenseObject
   }
 


### PR DESCRIPTION
### **Summary:**
Adds support for updating an expense with an optional card_id while maintaining backward compatibility with existing update behavior.

### **Changes:**

- Extended updateExpense GraphQL mutation to accept an optional card_id.
- Added a new service method to update expenses when card_id is provided.
- Updated resolver logic to route updates to the appropriate service method based on presence of card_id.

### **Risks:**

- Minimal. Conditional logic may affect update paths if card_id handling is incorrect.
- No behavior change when card_id is omitted.

### **Testing:**

- Verify updating expenses with and without card_id.
- Confirm existing update flows remain unaffected when card_id is not provided.
