### PR TITLE
Fix on overview page

### DIFF
--- a/services/expense.js
+++ b/services/expense.js
@@ -251,7 +251,7 @@ async function getExpenseEachDayInCurWeek(tag_value = null) {
     const tag_query = tag_value && tag_value != '' ? `tag = '${tag_value}' AND -- filter expenses tagged as '<tag_value>'`: '';
     const query = `
     SELECT COUNT(*) transactions_count, 
-    FLOOR(SUM(amount)) amount, date, to_char(date, 'Dy') day_name
+    FLOOR(SUM(amount)) amount, to_char(date, 'YYYY-MM-DD') AS date, to_char(date, 'Dy') day_name
     FROM expenses
     WHERE 
       ${tag_query}


### PR DESCRIPTION
## 📝 Summary

Updates the expense overview query to return a formatted, readable date string.

## 🔧 Changes

* Changed the `date` field to use `to_char(date, 'YYYY-MM-DD')` instead of returning the raw date value.

## ⚠️ Breaking Changes

* Yes: the `date` field type/format changes from a date value to a formatted string.

## 🧪 Testing

* Not explicitly tested in this PR.

## 📌 Notes

* Downstream consumers may need to adjust date parsing or comparisons.
