### PR TITLE
Implementation of search functionality within the expense listing API

### DIFF
--- a/resolvers/expense.js
+++ b/resolvers/expense.js
@@ -133,7 +133,7 @@ const expense_resolvers = {
     },
   },
   Query: {
-    expenses: async (_, { from_date, to_date }) => await getAllExpenses(1, from_date, to_date),
+    expenses: async (_, { search_param, from_date, to_date }) => await getAllExpenses(1, search_param, from_date, to_date),
     total_amount_in_mon: async (_, { mon_no }) =>
       await getTotalAmountSpentInMonth(mon_no),
     total_spends: async () => await getTotalAmountSpent(),

--- a/services/expense.js
+++ b/services/expense.js
@@ -29,86 +29,74 @@ async function addNewExpense(
   }
 }
 
-async function getAllExpenses(user_id, from_date, to_date) {
+async function getAllExpenses(user_id, search_param, from_date, to_date) {
   try {
     let expenses = null;
-    if (!from_date || !to_date) {
-      expenses = await Expense.findAndCountAll({
-        where: {
-          created_by: user_id,
-          is_deleted: 0,
-        },
-        attributes: [
-          "id",
-          "source_id",
-          "method_id",
-          "amount",
-          "description",
-          "date",
-          "created_by",
-          "updated_by",
-          "is_deleted",
-          "is_repayed",
-          "tag",
-          "category_id",
-          "card_id",
-          [sequelize.col("payment_cards.name"), "card_name"],
-        ],
-        raw: true,
-        include: [
-          {
-            model: paymentCards,
-            as: "payment_cards",
-            attributes: [],
-          },
-        ],
-        order: [
-          ["date", "DESC"],
-          ["id", "DESC"],
-        ],
-      });
-    } else {
-      expenses = await Expense.findAndCountAll({
-        where: {
-          created_by: user_id,
-          is_deleted: 0,
-          [Op.and]: [
-            where(fn("DATE", col("date")), {
-              [Op.gte]: from_date,
-              [Op.lte]: to_date,
-            }),
-          ],
-        },
-        attributes: [
-          "id",
-          "source_id",
-          "method_id",
-          "amount",
-          "description",
-          "date",
-          "created_by",
-          "updated_by",
-          "is_deleted",
-          "is_repayed",
-          "tag",
-          "category_id",
-          "card_id",
-          [sequelize.col("payment_cards.name"), "card_name"],
-        ],
-        raw: true,
-        include: [
-          {
-            model: paymentCards,
-            as: "payment_cards",
-            attributes: [],
-          },
-        ],
-        order: [
-          ["date", "DESC"],
-          ["id", "DESC"],
-        ],
-      });
+
+    let whereCondition = { created_by: user_id, is_deleted: 0 };
+
+    if (search_param) {
+      if (search_param.trim() !== "") {
+        try {
+          const parsedNumber = parseFloat(search_param);
+          if (!isNaN(parsedNumber) && parsedNumber > 0) {
+            whereCondition[Op.or] = [{ amount: parsedNumber }];
+          } else {
+            whereCondition[Op.or] = [
+              { description: { [Op.ilike]: `%${search_param}%` } },
+              { tag: { [Op.ilike]: `%${search_param}%` } },
+            ];
+          }
+        } catch (error) {
+          whereCondition[Op.or] = [
+            { description: { [Op.ilike]: `%${search_param}%` } },
+            { tag: { [Op.ilike]: `%${search_param}%` } },
+          ];
+        }
+      }
     }
+
+    if (from_date && to_date) {
+      whereCondition[Op.and] = [
+        where(fn("DATE", col("date")), {
+          [Op.gte]: from_date,
+          [Op.lte]: to_date,
+        }),
+      ];
+    }
+
+    expenses = await Expense.findAndCountAll({
+      where: whereCondition,
+      attributes: [
+        "id",
+        "source_id",
+        "method_id",
+        "amount",
+        "description",
+        "date",
+        "created_by",
+        "updated_by",
+        "is_deleted",
+        "is_repayed",
+        "tag",
+        "category_id",
+        "card_id",
+        [sequelize.col("payment_cards.name"), "card_name"],
+      ],
+      raw: true,
+      include: [
+        {
+          model: paymentCards,
+          as: "payment_cards",
+          attributes: [],
+        },
+      ],
+      order: [
+        ["date", "DESC"],
+        ["id", "DESC"],
+      ],
+    });
+
     if (expenses.count > 0)
       return { rows: expenses.rows, count: expenses.count };
     else return { rows: [], count: 0 };

--- a/typeDefs/expense.js
+++ b/typeDefs/expense.js
@@ -1,7 +1,7 @@
 const expenseTypeDef = /* GraphQL */ 
 `
   type Query {
-      expenses(from_date: String, to_date: String): ExpenseArray
+      expenses(search_param: String, from_date: String, to_date: String): ExpenseArray
       total_spends: Float!
       total_amount_in_mon(mon_no: Int): Float!
       date_wise_expenses(mon_no: Int): [DateExpenses]


### PR DESCRIPTION
## 📝 Summary

Adds search support to the `expenses` query and refactors expense retrieval to apply optional search and date filters through a single query.

## 🔧 Changes

* Updated `expenses` resolver to accept a new `search_param`.
* Modified `getAllExpenses` to build a dynamic `where` clause supporting:

  * amount matching when `search_param` is numeric
  * partial matching on `description` or `tag` when non-numeric
  * optional date range filtering when both `from_date` and `to_date` are provided
* Updated GraphQL schema to include `search_param` in the `expenses` query signature.

## ⚠️ Breaking Changes

* `expenses` query signature changed; clients must pass `search_param` as a new argument (optional, but the argument list has changed).

## 🧪 Testing

* Not tested (no test updates included).

## 📌 Notes

* Search ignores empty/whitespace `search_param` values.