### PR TITLE
Fix- Sequelize Operator correction during JOIN

### DIFF
--- a/services/expense.js
+++ b/services/expense.js
@@ -43,8 +43,8 @@ async function getAllExpenses(user_id, search_param, from_date, to_date) {
             whereCondition[Op.or] = [{ amount: parsedNumber }];
           } else {
             whereCondition[Op.or] = [
-              { description: { [Op.ilike]: `%${search_param}%` } },
-              { tag: { [Op.ilike]: `%${search_param}%` } },
+              { description: { [Op.iLike]: `%${search_param}%` } },
+              { tag: { [Op.iLike]: `%${search_param}%` } },
             ];
           }
         } catch (error) {

--- a/services/user.js
+++ b/services/user.js
@@ -16,7 +16,6 @@ async function createNewUser(
 ) {
   try {
     let encrypted_pwd = await encryptPassword(password);
-    console.log(`\nencrypted_pwd:\t${encrypted_pwd}\n`);
     return await User.create({
       first_name,
       last_name,


### PR DESCRIPTION
## 📝 Summary

Fixes the use of an incorrect Sequelize operator casing and removes a debug log statement.

## 🔧 Changes

* Updated Sequelize operator from `Op.ilike` to `Op.iLike` for `description` and `tag` search filters in `services/expense.js`.
* Removed a console log that printed the encrypted password in `services/user.js`.

## ⚠️ Breaking Changes

* None

## 🧪 Testing

* Not tested (no testing information provided).

## 📌 Notes

* This change corrects operator usage and cleans up sensitive debug output.