### PR TITLE
Changes to list the expenses paginated way

### DIFF
--- a/resolvers/expense.js
+++ b/resolvers/expense.js
@@ -133,7 +133,7 @@ const expense_resolvers = {
     },
   },
   Query: {
-    expenses: async (_, { search_param, from_date, to_date }) => await getAllExpenses(1, search_param, from_date, to_date),
+    expenses: async (_, { page_no, page_size, search_param, from_date, to_date }) => await getAllExpenses(page_no, page_size, 1, search_param, from_date, to_date),
     total_amount_in_mon: async (_, { mon_no }) =>
       await getTotalAmountSpentInMonth(mon_no),
     total_spends: async () => await getTotalAmountSpent(),

--- a/services/expense.js
+++ b/services/expense.js
@@ -29,7 +29,14 @@ async function addNewExpense(
   }
 }
 
-async function getAllExpenses(user_id, search_param, from_date, to_date) {
+async function getAllExpenses(
+  page_no,
+  page_size,
+  user_id,
+  search_param,
+  from_date,
+  to_date,
+) {
   try {
     let expenses = null;
 
@@ -65,42 +72,85 @@ async function getAllExpenses(user_id, search_param, from_date, to_date) {
       ];
     }
 
-    expenses = await Expense.findAndCountAll({
-      where: whereCondition,
-      attributes: [
-        "id",
-        "source_id",
-        "method_id",
-        "amount",
-        "description",
-        "date",
-        "created_by",
-        "updated_by",
-        "is_deleted",
-        "is_repayed",
-        "tag",
-        "category_id",
-        "card_id",
-        [sequelize.col("payment_cards.name"), "card_name"],
-      ],
-      raw: true,
-      include: [
-        {
-          model: paymentCards,
-          as: "payment_cards",
-          attributes: [],
-        },
-      ],
-      order: [
-        ["date", "DESC"],
-        ["id", "DESC"],
-      ],
-    });
+    const offset = ((page_no && page_no > 0) && (page_size && page_size > 0)) ? (page_no - 1) * page_size : 0;
+    const limit = page_size ? page_size : 0;
+
+    console.log("whereCondition:", whereCondition);
+    console.log(`\noffset${offset}\t limit${limit}`);
+    
+
+    if (limit > 0)
+      expenses = await Expense.findAndCountAll({
+        where: whereCondition,
+        attributes: [
+          "id",
+          "source_id",
+          "method_id",
+          "amount",
+          "description",
+          "date",
+          "created_by",
+          "updated_by",
+          "is_deleted",
+          "is_repayed",
+          "tag",
+          "category_id",
+          "card_id",
+          [sequelize.col("payment_cards.name"), "card_name"],
+        ],
+        raw: true,
+        include: [
+          {
+            model: paymentCards,
+            as: "payment_cards",
+            attributes: [],
+          },
+        ],
+        limit,
+        offset,
+        order: [
+          ["date", "DESC"],
+          ["id", "DESC"],
+        ],
+      });
+    else
+      expenses = await Expense.findAndCountAll({
+        where: whereCondition,
+        attributes: [
+          "id",
+          "source_id",
+          "method_id",
+          "amount",
+          "description",
+          "date",
+          "created_by",
+          "updated_by",
+          "is_deleted",
+          "is_repayed",
+          "tag",
+          "category_id",
+          "card_id",
+          [sequelize.col("payment_cards.name"), "card_name"],
+        ],
+        raw: true,
+        include: [
+          {
+            model: paymentCards,
+            as: "payment_cards",
+            attributes: [],
+          },
+        ],
+        order: [
+          ["date", "DESC"],
+          ["id", "DESC"],
+        ],
+      });
 
     if (expenses.count > 0)
       return { rows: expenses.rows, count: expenses.count };
     else return { rows: [], count: 0 };
   } catch (error) {
+    console.log("Error in getAllExpenses service:", error);
     throw error;
   }
 }

--- a/typeDefs/expense.js
+++ b/typeDefs/expense.js
@@ -1,7 +1,7 @@
 const expenseTypeDef = /* GraphQL */ 
 `
   type Query {
-      expenses(search_param: String, from_date: String, to_date: String): ExpenseArray
+      expenses(page_no: Int, page_size: Int, search_param: String, from_date: String, to_date: String): ExpenseArray
       total_spends: Float!
       total_amount_in_mon(mon_no: Int): Float!
       date_wise_expenses(mon_no: Int): [DateExpenses]


### PR DESCRIPTION
## 📝 Summary

Adds pagination support to the expenses query by introducing page number and page size parameters, updating the resolver, service, and GraphQL schema accordingly.

## 🔧 Changes

* Updated GraphQL `expenses` query to accept `page_no` and `page_size`
* Modified `expenses` resolver to pass pagination parameters to the service
* Refactored `getAllExpenses` service to support `limit` and `offset`
* Applied conditional pagination logic (paginated vs non-paginated query)
* Preserved existing filtering, sorting, and joins

## ⚠️ Breaking Changes

* The `expenses` resolver signature has changed to include pagination arguments
* Existing callers not passing the new arguments may need updates

## 🧪 Testing

* Manually tested the `expenses` query with and without pagination parameters

## 📌 Notes

* Pagination is applied only when `page_size > 0`
* Default behavior falls back to fetching all records when pagination is not provided