### PR TITLE
Implementation changes in the Expense listing API getting data as per logged-in user id

### DIFF
--- a/resolvers/expense.js
+++ b/resolvers/expense.js
@@ -133,7 +133,7 @@ const expense_resolvers = {
     },
   },
   Query: {
-    expenses: async (_, { page_no, page_size, search_param, from_date, to_date }) => await getAllExpenses(page_no, page_size, 1, search_param, from_date, to_date),
+    expenses: async (_, { page_no, page_size, search_param, from_date, to_date }, { logged_userid }) => await getAllExpenses(page_no, page_size, logged_userid, search_param, from_date, to_date), // instead of hard coded 1 how to get the value of req.logged_userid
     total_amount_in_mon: async (_, { mon_no }) =>
       await getTotalAmountSpentInMonth(mon_no),
     total_spends: async () => await getTotalAmountSpent(),

--- a/services/expense.js
+++ b/services/expense.js
@@ -36,7 +36,7 @@ async function getAllExpenses(
   search_param,
   from_date,
   to_date,
-) {
+) {  
   try {
     let expenses = null;
 
@@ -74,10 +74,6 @@ async function getAllExpenses(
 
     const offset = ((page_no && page_no > 0) && (page_size && page_size > 0)) ? (page_no - 1) * page_size : 0;
     const limit = page_size ? page_size : 0;
-
-    console.log("whereCondition:", whereCondition);
-    console.log(`\noffset${offset}\t limit${limit}`);
-    
 
     if (limit > 0)
       expenses = await Expense.findAndCountAll({


### PR DESCRIPTION
## 📝 Summary

Aligns expense fetching with the login flow by using the logged-in user context instead of a hardcoded user ID.

## 🔧 Changes

* Updated `expenses` resolver to pass `logged_userid` from GraphQL context to the service layer.
* Removed hardcoded user ID (`1`) from expense retrieval.
* Cleaned up debug `console.log` statements in the expense service.

## ⚠️ Breaking Changes

* Expense queries are now scoped to the logged-in user instead of a fixed user ID.

## 🧪 Testing

* Not tested.

## 📌 Notes

* Requires `logged_userid` to be correctly populated in the GraphQL context.
