### PR TITLE
Implementation for setting the logged-in user id in the update expense

### DIFF
--- a/resolvers/expense.js
+++ b/resolvers/expense.js
@@ -90,8 +90,6 @@ const expense_resolvers = {
         amount,
         description,
         date,
-        created_by,
-        updated_by,
         tag,
         is_repayed,
         card_id,
@@ -99,37 +97,60 @@ const expense_resolvers = {
       { logged_userid },
     ) => {
       let updateResult;
-      if (card_id) {
-        // Call the V2 function if card_id is provided
-        updateResult = await updateAnExpenseV2(
-          id,
-          source_id,
-          method_id,
-          amount,
-          description,
-          date,
-          created_by,
-          updated_by,
-          tag,
-          is_repayed,
-          card_id,
-        );
-      } else {
-        // Present for backend compatibility
-        updateResult = await updateAnExpense(
-          id,
-          source_id,
-          method_id,
-          amount,
-          description,
-          date,
-          created_by,
-          updated_by,
-          tag,
-          is_repayed,
-        );
-      }
-      return await getExpensesDetailsById(id);
+
+      let expenses = await getExpensesOwners([id]);
+      let expense_owners_array = expenses.map((exp) =>
+        parseInt(exp.created_by),
+      );
+      const allEqual = (arr) => arr.every((val) => val === arr[0]);
+
+      if (expense_owners_array.length == ids.length)
+        if (allEqual(expense_owners_array)) {
+          if (expense_owners_array[0] != logged_userid) {
+            if (card_id) {
+              // Call the V2 function if card_id is provided
+              updateResult = await updateAnExpenseV2(
+                id,
+                source_id,
+                method_id,
+                amount,
+                description,
+                date,
+                logged_userid,
+                tag,
+                is_repayed,
+                card_id,
+              );
+            } else {
+              // Present for backend compatibility
+              updateResult = await updateAnExpense(
+                id,
+                source_id,
+                method_id,
+                amount,
+                description,
+                date,
+                logged_userid,
+                tag,
+                is_repayed,
+              );
+            }
+            return await getExpensesDetailsById(id);
+          } else
+            return {
+              deleted_expenses: [],
+              message: "Cannot update since you do not own these expense's",
+            };
+        } else
+          return {
+            deleted_expenses: [],
+            message: "Cannot update since you do not own these expense's",
+          };
+      else
+        return {
+          deleted_expenses: [],
+          message: "Cannot update since you do not own these expense's",
+        };
     },
   },
   Query: {

--- a/services/expense.js
+++ b/services/expense.js
@@ -170,7 +170,6 @@ async function updateAnExpense(
   amount,
   description,
   date,
-  created_by,
   updated_by,
   tag,
   is_repayed,
@@ -182,7 +181,6 @@ async function updateAnExpense(
     if (amount !== undefined) updateFields.amount = amount;
     if (description !== undefined) updateFields.description = description;
     if (date !== undefined) updateFields.date = date;
-    if (created_by !== undefined) updateFields.created_by = created_by;
     if (updated_by !== undefined) updateFields.updated_by = updated_by;
     if (tag !== undefined) updateFields.tag = tag;
     if (is_repayed !== undefined) updateFields.is_repayed = is_repayed;
@@ -445,7 +443,6 @@ async function updateAnExpenseV2(
   amount,
   description,
   date,
-  created_by,
   updated_by,
   tag,
   is_repayed,
@@ -458,7 +455,6 @@ async function updateAnExpenseV2(
     if (amount !== undefined) updateFields.amount = amount;
     if (description !== undefined) updateFields.description = description;
     if (date !== undefined) updateFields.date = date;
-    if (created_by !== undefined) updateFields.created_by = created_by;
     if (updated_by !== undefined) updateFields.updated_by = updated_by;
     if (tag !== undefined) updateFields.tag = tag;
     if (is_repayed !== undefined) updateFields.is_repayed = is_repayed;

--- a/typeDefs/expense.js
+++ b/typeDefs/expense.js
@@ -60,7 +60,7 @@ const expenseTypeDef = /* GraphQL */
 
   type Mutation {
       createExpense(source_id: Int, source: String, method_id: Int, method: String, amount: Float, description: String, date: String, tag: String, card_id: Int): Expense
-      updateExpense(id: Int!, source_id: Int, method_id: Int, amount: Float, description: String, date: String, created_by: Int, updated_by: Int, tag: String, is_repayed: Int ,card_id: Int): Expense
+      updateExpense(id: Int!, source_id: Int, method_id: Int, amount: Float, description: String, date: String, tag: String, is_repayed: Int ,card_id: Int): Expense
       deleteExpense(ids: [Int]): deleteExpenseObject
   }
 


### PR DESCRIPTION
## 📝 Summary

Updates expense update logic to align with the login-based ownership flow by enforcing user ownership checks and removing client-controlled ownership fields.

## 🔧 Changes

* Added ownership validation before allowing an expense update.
* Ensures only the logged-in user (derived from context) can update their own expenses.
* Refactored update flow to consistently use `logged_userid` instead of client-passed fields.
* Retained conditional handling for card-based (`updateAnExpenseV2`) and non-card updates.
* Removed `created_by` and `updated_by` handling from service-level update logic.
* Updated GraphQL `updateExpense` mutation signature to remove ownership-related arguments.

## ⚠️ Breaking Changes

* `updateExpense` mutation no longer accepts `created_by` or `updated_by` arguments.
* Clients can no longer update expenses they do not own, even if previously possible.

## 🧪 Testing

* Not tested.

## 📌 Notes

* Expense ownership is now strictly enforced at the resolver level.
* Error responses return a message when ownership validation fails.