### PR TITLE
Creation of category and sub-category APIs

### DIFF
--- a/models/transaction_category.js
+++ b/models/transaction_category.js
@@ -1,0 +1,35 @@
+const { sequelize } = require("../config/database");
+const { DataTypes } = require("sequelize");
+
+const TransactionCategory = sequelize.define('TransactionCategory', {
+  id: {
+    type: DataTypes.BIGINT,
+    primaryKey: true,
+    autoIncrement: true,
+  },
+  name: {
+    type: DataTypes.TEXT,
+    allowNull: false,
+  },
+  is_active: {
+    type: DataTypes.SMALLINT,
+    defaultValue: 0,
+  },
+  is_deleted: {
+    type: DataTypes.SMALLINT,
+    defaultValue: 0,
+  },
+  created_by: {
+    type: DataTypes.BIGINT,
+    defaultValue: 1,
+  },
+  updated_by: {
+    type: DataTypes.BIGINT,
+    defaultValue: 1,
+  },
+}, {
+  tableName: 'transaction_categories',
+  timestamps: false,
+});
+
+module.exports = TransactionCategory;

--- a/models/transaction_sub_category.js
+++ b/models/transaction_sub_category.js
@@ -1,0 +1,47 @@
+const { sequelize } = require("../config/database");
+const { DataTypes } = require("sequelize");
+const TransactionCategory = require('./transaction_category');
+
+const TransactionSubCategory = sequelize.define('TransactionSubCategory', {
+  id: {
+    type: DataTypes.BIGINT,
+    primaryKey: true,
+    autoIncrement: true,
+  },
+  name: {
+    type: DataTypes.TEXT,
+    allowNull: false,
+  },
+  is_active: {
+    type: DataTypes.SMALLINT,
+    defaultValue: 0,
+  },
+  is_deleted: {
+    type: DataTypes.SMALLINT,
+    defaultValue: 0,
+  },
+  created_by: {
+    type: DataTypes.BIGINT,
+    defaultValue: 1,
+  },
+  updated_by: {
+    type: DataTypes.BIGINT,
+    defaultValue: 1,
+  },
+  category_id: {
+    type: DataTypes.BIGINT,
+    allowNull: false,
+    references: {
+      model: TransactionCategory,
+      key: 'id',
+    },
+  },
+}, {
+  tableName: 'transaction_sub_categories',
+  timestamps: false,
+});
+
+TransactionSubCategory.belongsTo(TransactionCategory, { foreignKey: 'category_id' });
+TransactionCategory.hasMany(TransactionSubCategory, { foreignKey: 'category_id', as: 'subCategories' });
+
+module.exports = TransactionSubCategory;

--- a/resolvers/transaction_category.js
+++ b/resolvers/transaction_category.js
@@ -1,0 +1,27 @@
+const { getAllTransactionCategories, getTransactionSubCategoriesByCategoryId } = require('../services/transaction_category');
+
+const TransactionSubCategory = require('../models/transaction_sub_category');
+const transactionCategoryResolvers = {
+  Query: {
+    getAllTransactionCategories: async () => {
+      return await getAllTransactionCategories();
+    },
+    getTransactionSubCategoriesByCategoryId: async (_, { id }) => {
+      return await getTransactionSubCategoriesByCategoryId(id);
+    },
+  },
+  TransactionCategory: {
+    subCategories: async (parent) => {
+      return await TransactionSubCategory.findAll({
+        where: { category_id: parent.id },
+      });
+    },
+  },
+  TransactionSubCategory: {
+    category: async (parent) => {
+      return await TransactionCategory.findByPk(parent.category_id);
+    },
+  },
+};
+
+module.exports = transactionCategoryResolvers;

--- a/services/transaction_category.js
+++ b/services/transaction_category.js
@@ -1,0 +1,19 @@
+const TransactionCategory = require('../models/transaction_category');
+const TransactionSubCategory = require('../models/transaction_sub_category');
+
+async function getAllTransactionCategories() {
+  return await TransactionCategory.findAll({
+    include: [{ model: TransactionSubCategory, as: 'subCategories' }],
+  });
+}
+
+async function getTransactionSubCategoriesByCategoryId(categoryId) {
+  return await TransactionSubCategory.findAll({
+    where: { category_id: categoryId },
+  });
+}
+
+module.exports = {
+  getAllTransactionCategories,
+  getTransactionSubCategoriesByCategoryId,
+};

--- a/typeDefs/transaction_category.js
+++ b/typeDefs/transaction_category.js
@@ -1,0 +1,31 @@
+// const { gql } = require('apollo-server-express');
+
+const transactionCategoryTypeDefs = `
+  type TransactionCategory {
+    id: ID!
+    name: String!
+    is_active: Int!
+    is_deleted: Int!
+    created_by: Int!
+    updated_by: Int!
+    subCategories: [TransactionSubCategory]
+  }
+
+  type TransactionSubCategory {
+    id: ID!
+    name: String!
+    is_active: Int!
+    is_deleted: Int!
+    created_by: Int!
+    updated_by: Int!
+    category_id: ID!
+    category: TransactionCategory
+  }
+
+  type Query {
+    getAllTransactionCategories: [TransactionCategory]
+    getTransactionSubCategoriesByCategoryId(id: ID!): [TransactionSubCategory]
+  }
+`;
+
+module.exports = transactionCategoryTypeDefs;


### PR DESCRIPTION
## 📝 Summary

Add support for transaction categories and subcategories, including Sequelize models, GraphQL type definitions, resolvers, and services.

## 🔧 Changes

* Created `TransactionCategory` Sequelize model mapped to `transaction_categories` table.
* Created `TransactionSubCategory` Sequelize model mapped to `transaction_sub_categories` table with `category_id` foreign key.
* Defined associations:

  * `TransactionCategory.hasMany(TransactionSubCategory, as: 'subCategories')`
  * `TransactionSubCategory.belongsTo(TransactionCategory)`
* Added service methods:

  * `getAllTransactionCategories` (with included subcategories)
  * `getTransactionSubCategoriesByCategoryId`
* Implemented GraphQL resolvers:

  * Queries: `getAllTransactionCategories`, `getTransactionSubCategoriesByCategoryId`
  * Field resolvers for `TransactionCategory.subCategories` and `TransactionSubCategory.category`
* Added GraphQL type definitions for `TransactionCategory`, `TransactionSubCategory`, and related queries.

## ⚠️ Breaking Changes

* None

## 🧪 Testing

* Not explicitly tested (no tests included in this PR context).

## 📌 Notes

* Requires corresponding database tables: `transaction_categories` and `transaction_sub_categories`.
* Assumes foreign key constraint on `transaction_sub_categories.category_id`.