### PR TITLE
Implementation : Add / Edit Expense to accept sub-category-id  with or without credit card

### DIFF
--- a/models/expense.js
+++ b/models/expense.js
@@ -53,7 +53,7 @@ const Expense = sequelize.define(
       type: DataTypes.STRING,
       allowNull: true,
     },
-    category_id: {
+    sub_category_id: {
       type: DataTypes.INTEGER,
       allowNull: true,
     },

--- a/resolvers/expense.js
+++ b/resolvers/expense.js
@@ -24,7 +24,7 @@ const expense_resolvers = {
     // parent, argument, context
     createExpense: async (
       _,
-      { source_id, method_id, amount, description, date, tag, card_id },
+      { source_id, method_id, amount, description, date, tag, card_id, sub_category_id },
       { logged_userid },
     ) => {
       // If the card_id is provided, use the V2 function to include it and create an expense with card association
@@ -39,6 +39,7 @@ const expense_resolvers = {
           logged_userid,
           tag,
           card_id,
+          sub_category_id
         );
       else
         await addNewExpense(
@@ -50,6 +51,7 @@ const expense_resolvers = {
           logged_userid,
           logged_userid,
           tag,
+          sub_category_id
         );
     },
     deleteExpense: async (_, { ids }, { logged_userid }) => {
@@ -93,6 +95,7 @@ const expense_resolvers = {
         tag,
         is_repayed,
         card_id,
+        sub_category_id
       },
       { logged_userid },
     ) => {
@@ -119,6 +122,7 @@ const expense_resolvers = {
                 tag,
                 is_repayed,
                 card_id,
+                sub_category_id
               );
             } else {
               // Present for backend compatibility
@@ -132,6 +136,7 @@ const expense_resolvers = {
                 logged_userid,
                 tag,
                 is_repayed,
+                sub_category_id,
               );
             }
 

--- a/services/expense.js
+++ b/services/expense.js
@@ -12,6 +12,7 @@ async function addNewExpense(
   created_by,
   updated_by,
   tag,
+  sub_category_id = null,
 ) {
   try {
     return await Expense.create({
@@ -23,6 +24,7 @@ async function addNewExpense(
       created_by,
       updated_by,
       tag,
+      sub_category_id,
     });
   } catch (error) {
     throw error;
@@ -169,6 +171,7 @@ async function updateAnExpense(
   updated_by,
   tag,
   is_repayed,
+  sub_category_id = null
 ) {
   try {
     const updateFields = {};
@@ -180,6 +183,9 @@ async function updateAnExpense(
     if (updated_by !== undefined) updateFields.updated_by = updated_by;
     if (tag !== undefined) updateFields.tag = tag;
     if (is_repayed !== undefined) updateFields.is_repayed = is_repayed;
+    if (sub_category_id !==  null && sub_category_id !== undefined) updateFields.sub_category_id = sub_category_id;
+
+    console.log("updateFields in updateAnExpense service:", JSON.stringify(updateFields));
 
     if (Object.keys(updateFields).length > 0) {
       updateFields.updated_at = new Date();
@@ -414,6 +420,7 @@ async function addNewExpenseV2(
   updated_by,
   tag,
   card_id,
+  sub_category_id = null
 ) {
   try {
     return await Expense.create({
@@ -426,6 +433,7 @@ async function addNewExpenseV2(
       updated_by,
       tag,
       card_id,
+      sub_category_id
     });
   } catch (error) {
     throw error;
@@ -443,6 +451,7 @@ async function updateAnExpenseV2(
   tag,
   is_repayed,
   card_id,
+  sub_category_id = null
 ) {
   try {
     const updateFields = {};
@@ -455,7 +464,9 @@ async function updateAnExpenseV2(
     if (tag !== undefined) updateFields.tag = tag;
     if (is_repayed !== undefined) updateFields.is_repayed = is_repayed;
     if (card_id !== undefined) updateFields.card_id = card_id;
+    if (sub_category_id !==  null && sub_category_id !== undefined) updateFields.sub_category_id = sub_category_id;
 
+    console.log("updateFields in updateAnExpenseV2 service:", JSON.stringify(updateFields));
     if (Object.keys(updateFields).length > 0) {
       updateFields.updated_at = new Date();
       return await Expense.update(updateFields, { where: { id: expense_id } });

--- a/typeDefs/expense.js
+++ b/typeDefs/expense.js
@@ -59,8 +59,8 @@ const expenseTypeDef = /* GraphQL */
   }
 
   type Mutation {
-      createExpense(source_id: Int, source: String, method_id: Int, method: String, amount: Float, description: String, date: String, tag: String, card_id: Int): Expense
-      updateExpense(id: Int!, source_id: Int, method_id: Int, amount: Float, description: String, date: String, tag: String, is_repayed: Int ,card_id: Int): Expense
+      createExpense(source_id: Int, source: String, method_id: Int, method: String, amount: Float, description: String, date: String, tag: String, card_id: Int, sub_category_id: Int): Expense
+      updateExpense(id: Int!, source_id: Int, method_id: Int, amount: Float, description: String, date: String, tag: String, is_repayed: Int ,card_id: Int, sub_category_id: Int): Expense
       deleteExpense(ids: [Int]): deleteExpenseObject
   }
 


### PR DESCRIPTION
## 📝 Summary

Update expense creation and update flows to accept and persist `sub_category_id` instead of `category_id`.

## 🔧 Changes

* **Model**

  * Replaced `category_id` field with `sub_category_id` in `models/expense.js`.
* **GraphQL TypeDefs**

  * Added `sub_category_id: Int` argument to:

    * `createExpense`
    * `updateExpense`
* **Resolvers**

  * Updated `createExpense` and `updateExpense` resolvers to accept and pass `sub_category_id`.
* **Services**

  * Added `sub_category_id` parameter (default `null`) to expense service methods.
  * Conditionally includes `sub_category_id` in `updateFields` when provided.
  * Added console logs for `updateFields` in update services.

## ⚠️ Breaking Changes

* `category_id` has been replaced with `sub_category_id` in the Expense model and related flows. Existing consumers using `category_id` will break.

## 🧪 Testing

* Not explicitly tested (no tests included in this PR context).

## 📌 Notes

* Ensure database schema aligns with `sub_category_id` change.
* Clients must update mutations to use `sub_category_id`.
