### PR TITLE
Get Expense to list the category and subCategory details

### DIFF
--- a/models/expense.js
+++ b/models/expense.js
@@ -1,6 +1,8 @@
 const { sequelize } = require("../config/database")
 const { DataTypes } = require("sequelize");
 const paymentCards = require("./cards");
+const TransactionSubCategory = require("./transaction_sub_category");
+
 
 const Expense = sequelize.define(
   "expenses",
@@ -83,6 +85,11 @@ Expense.hasOne(paymentCards, {
   sourceKey: 'card_id',
   foreignKey: 'id',
   as: 'payment_cards'
+});
+Expense.hasOne(TransactionSubCategory, {
+  sourceKey: 'sub_category_id',
+  foreignKey: 'id',
+  as: 'sub_category'
 });
 
 

--- a/models/transaction_sub_category.js
+++ b/models/transaction_sub_category.js
@@ -41,7 +41,7 @@ const TransactionSubCategory = sequelize.define('TransactionSubCategory', {
   timestamps: false,
 });
 
-TransactionSubCategory.belongsTo(TransactionCategory, { foreignKey: 'category_id' });
+TransactionSubCategory.belongsTo(TransactionCategory, { foreignKey: 'category_id', as: 'transaction_category' });
 TransactionCategory.hasMany(TransactionSubCategory, { foreignKey: 'category_id', as: 'subCategories' });
 
 module.exports = TransactionSubCategory;

--- a/services/expense.js
+++ b/services/expense.js
@@ -2,6 +2,8 @@ const Expense = require("../models/expense");
 const { Op, fn, col, where } = require("sequelize");
 const { sequelize } = require("../config/database");
 const paymentCards = require("../models/cards");
+const TransactionSubCategory = require("../models/transaction_sub_category");
+const TransactionCategory = require("../models/transaction_category");
 
 async function addNewExpense(
   source_id,
@@ -95,6 +97,8 @@ async function getAllExpenses(
           "sub_category_id",
           "card_id",
           [sequelize.col("payment_cards.name"), "card_name"],
+          [sequelize.col("sub_category.name"), "sub_category_name"],
+          [sequelize.col("sub_category->transaction_category.name"), "category_name"],
         ],
         raw: true,
         include: [
@@ -102,6 +106,22 @@ async function getAllExpenses(
             model: paymentCards,
             as: "payment_cards",
             attributes: [],
+          },
+          {
+            model: TransactionSubCategory,
+            as: "sub_category",
+            left: true,
+            attributes: [],
+            required: false,
+            where: { is_deleted: 0 },
+            include: [
+              {
+                model: TransactionCategory,
+                as: "transaction_category",
+                attributes: ['name'],
+                where: { is_deleted: 0 },
+              },
+            ],
           },
         ],
         limit,
@@ -129,6 +149,8 @@ async function getAllExpenses(
           "sub_category_id",
           "card_id",
           [sequelize.col("payment_cards.name"), "card_name"],
+          [sequelize.col("sub_category.name"), "sub_category_name"],
+          [sequelize.col("sub_category->transaction_category.name"), "category_name"],
         ],
         raw: true,
         include: [
@@ -136,6 +158,22 @@ async function getAllExpenses(
             model: paymentCards,
             as: "payment_cards",
             attributes: [],
+          },
+          {
+            model: TransactionSubCategory,
+            as: "sub_category",
+            left: true,
+            attributes: [],
+            required: false,
+            where: { is_deleted: 0 },
+            include: [
+              {
+                model: TransactionCategory,
+                as: "transaction_category",
+                attributes: ['name'],
+                where: { is_deleted: 0 },
+              },
+            ],
           },
         ],
         order: [

--- a/typeDefs/expense.js
+++ b/typeDefs/expense.js
@@ -40,6 +40,8 @@ const expenseTypeDef = /* GraphQL */
     sub_category_id: Int
     card_id: Int
     card_name: String
+    sub_category_name: String
+    category_name: String
   }
 
   type deleteExpenseObject {


### PR DESCRIPTION
## 📝 Summary

Enhances expense queries to include related sub-category and category names via Sequelize associations and updates GraphQL schema accordingly.

## 🔧 Changes

* Added `Expense.hasOne` association to `TransactionSubCategory` as `sub_category` in `models/expense.js`.
* Updated `TransactionSubCategory.belongsTo` to use alias `transaction_category` in `models/transaction_sub_category.js`.
* Extended expense service queries to:

  * Join `TransactionSubCategory` (alias: `sub_category`) with `is_deleted: 0` filter.
  * Nested include of `TransactionCategory` (alias: `transaction_category`) with `is_deleted: 0` filter.
  * Select computed fields:

    * `sub_category_name`
    * `category_name`
* Updated GraphQL `Expense` type definition to include:

  * `sub_category_name: String`
  * `category_name: String`

## ⚠️ Breaking Changes

* Updated association alias for `TransactionSubCategory.belongsTo(TransactionCategory)` to `transaction_category`, which may affect existing queries relying on the previous default alias.

## 🧪 Testing

Tested Okay !

## 📌 Notes

* Ensure any existing Sequelize includes referencing `TransactionCategory` are updated to use the new `transaction_category` alias.
